### PR TITLE
FIX logic executed on e2e test to delete cloud function

### DIFF
--- a/tests/bin/run.sh
+++ b/tests/bin/run.sh
@@ -63,7 +63,13 @@ gsutil cp ${TRANSFORM} ${BUCKET}/bqds/${TABLE}.transform.sql
 
 echo "Deploying cloud function" 
 cd ${FUNCTION_DIR}
-npm run deploy -- --trigger-bucket=${BUCKET} 
+DEPLOY_OUT=$(npm run deploy -- --trigger-bucket=${BUCKET}) 
+
+FUNCTION_NAME_REGEXP="name.*functions[\/]([a-zA-Z\d-]+)"
+[[ $DEPLOY_OUT =~ $FUNCTION_NAME_REGEXP ]]
+FUNCTION_NAME="${BASH_REMATCH[1]}"
+
+echo "${DEPLOY_OUT}"
 
 if [ $? -ne 0 ]
 then
@@ -137,9 +143,9 @@ echo "Validation complete"
 
 ##### Tear-down steps 
 
-echo "Removing cloud function $(basename ${FUNCTION_DIR})" 
+echo "Removing cloud function $FUNCTION_NAME" 
 cd ${FUNCTION_DIR}
-gcloud functions delete $(basename ${FUNCTION_DIR}) --quiet
+gcloud functions delete $FUNCTION_NAME --quiet
 
 if [ $? -ne 0 ]
 then


### PR DESCRIPTION
### All Submissions:

The cloud function delete logic:
https://github.com/GoogleCloudPlatform/bq-datashare-toolkit/blob/83afbb93847eb750ac788bee1bcf3a68f8e0b941/tests/bin/run.sh#L142

was affected after the function folder rename, the folder name is no longer the name of the cloud function.

This new logic is extracting the function name from the deploy command, which will be safer from changes.

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [] Have you lint your code locally prior to submission? N/A

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable? N/A
* [x] Have you successfully ran tests with your changes locally?
