### PR TITLE
updates for specifying node version in entitlements docker manifest

### DIFF
--- a/entitlements/bin/Dockerfile
+++ b/entitlements/bin/Dockerfile
@@ -1,18 +1,7 @@
-FROM node:latest
+FROM node:12.6-alpine
 
 WORKDIR /app
 
 ADD ./bqdsEntitlements /app
 
 RUN npm install -g
-
-# Downloading gcloud package
-RUN curl https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz > /tmp/google-cloud-sdk.tar.gz
-
-# Installing the package
-RUN mkdir -p /usr/local/gcloud \
-  && tar -C /usr/local/gcloud -xvf /tmp/google-cloud-sdk.tar.gz \
-  && /usr/local/gcloud/google-cloud-sdk/install.sh
-
-# Adding the package path to local
-ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin

--- a/entitlements/bin/run.sh
+++ b/entitlements/bin/run.sh
@@ -42,4 +42,4 @@ docker run -it \
     -v "${CREDENTIAL_FILE_PATH}":"/app/credentials/${CREDENTIAL_FILE_NAME}" \
     -e GOOGLE_APPLICATION_CREDENTIALS="/app/credentials/${CREDENTIAL_FILE_NAME}" \
     -e CONFIG_FILE_PATH="${IMAGE_CONFIG_FILE_PATH}" \
-    entitlement-engine:v1 bash
+    entitlement-engine:v1 ash


### PR DESCRIPTION
Updates for specifying node version in entitlements docker manifest for #58 
* updated Dockerfile with node:12.6-alpine
* removed unnecessary gcloud sdk install
* changed `run.sh`'s to *ash*

Tested locally via sample mlb's simple.json
```
sh run.sh /Users/chrispage/github.com/GoogleCloudPlatform/bq-datashare-toolkit/temp/bqds-entitlements-mgr.json /Users/chrispage/github.com/GoogleCloudPlatform/bq-datashare-toolkit/temp/mlb_config.json
```

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [x] Does your submission pass tests? 
2. [x] Have you lint your code locally prior to submission? N/A

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable? N/A
* [x] Have you successfully ran tests with your changes locally? Yes
