### PR TITLE
User not authorized to the user access view

### DIFF
--- a/api/v1alpha/src/datasets/dataManager.js
+++ b/api/v1alpha/src/datasets/dataManager.js
@@ -547,7 +547,7 @@ async function createView(view, overrideSql) {
                 // Need to authorize the view from the source tables
                 await bigqueryUtil.shareAuthorizeView(source.datasetId, view.projectId, view.datasetId, view.name, viewCreated);
             }
-            if (source.accessControl && source.accessControl.enabled === true && cfg.cdsDatasetId !== view.datasetId) {
+            if (view.accessControl && view.accessControl.enabled === true && cfg.cdsDatasetId !== view.datasetId) {
                 await bigqueryUtil.shareAuthorizeView(cfg.cdsDatasetId, view.projectId, view.datasetId, view.name, viewCreated);
             }
         }


### PR DESCRIPTION
When the authorized view is created, the 'Datashare' dataset needs to authorize the new view for access if access_control is used.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?