### PR TITLE
Add UI switch and enableAutoApprove schema field to policies

### DIFF
--- a/api/v1alpha/src/admin/bq/schema/policy.json
+++ b/api/v1alpha/src/admin/bq/schema/policy.json
@@ -29,7 +29,7 @@
             "mode": "NULLABLE",
             "name": "isTableBased",
             "type": "BOOLEAN",
-            "description": "The flag to indicate if the policy is table-based otherwisre dataset-based"
+            "description": "The flag to indicate if the policy is table-based otherwise dataset-based"
         },
         {
             "fields": [
@@ -87,6 +87,12 @@
                     "mode": "REQUIRED",
                     "name": "planId",
                     "type": "STRING"
+                },
+                {
+                    "mode": "REQUIRED",
+                    "name": "enableAutoApprove",
+                    "type": "BOOLEAN",
+                    "description": "The flag indicates if the purchase through Marketplace should be auto-approved and entitled for the subscriber."
                 }
             ]
         },

--- a/frontend/src/components/EditPolicy.vue
+++ b/frontend/src/components/EditPolicy.vue
@@ -220,6 +220,11 @@
                   label="Plan Id"
                 ></v-text-field>
               </ValidationProvider>
+              <v-switch
+                v-if="false"
+                label="Enable Purchase Auto Approve"
+                v-model="policy.marketplace.enableAutoApprove"
+              ></v-switch>
             </v-expansion-panel-content>
           </v-expansion-panel>
           <v-expansion-panel v-if="editMode">
@@ -503,7 +508,7 @@ export default {
       rowAccessTags: [],
       initialDatasets: [],
       initialRowAccessTags: [],
-      marketplace: { solutionId: null, planId: null }
+      marketplace: { solutionId: null, planId: null, enableAutoApprove: false }
     },
     datasetSearch: '',
     tableSearch: '',
@@ -698,7 +703,9 @@ export default {
           ) {
             data.marketplace = {
               solutionId: this.policy.marketplace.solutionId,
-              planId: this.policy.marketplace.planId
+              planId: this.policy.marketplace.planId,
+              enableAutoApprove:
+                this.policy.marketplace.enableAutoApprove || false
             };
           }
 
@@ -768,7 +775,11 @@ export default {
             if (p.marketplace) {
               this.policy.marketplace = p.marketplace;
             } else {
-              this.policy.marketplace = { solutionId: '', planId: '' };
+              this.policy.marketplace = {
+                solutionId: '',
+                planId: '',
+                enableAutoApprove: false
+              };
             }
           }
           this.loading = false;


### PR DESCRIPTION
This adds the UI switch and field to schema enableAutoApprove to the policies table. Will raise a separate PR with the pub/sub integration.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [X] Does your submission pass tests?
2. [X] Have you lint your code locally prior to submission?