### PR TITLE
fixes #271 - changed API deployment name to ds-api from cds-api

### DIFF
--- a/api/v1alpha/cloudbuild.yaml
+++ b/api/v1alpha/cloudbuild.yaml
@@ -2,9 +2,9 @@ steps:
 - name: "gcr.io/cloud-builders/docker"
   args:
   - build
-  - "--tag=gcr.io/$PROJECT_ID/cds-api:$TAG_NAME"
+  - "--tag=gcr.io/$PROJECT_ID/ds-api:$TAG_NAME"
   - "--file=./api/v1alpha/Dockerfile"
   - .
 images:
-  - "gcr.io/$PROJECT_ID/cds-api:$TAG_NAME"
+  - "gcr.io/$PROJECT_ID/ds-api:$TAG_NAME"
 


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

This updates the deployment API name to ds-api.