### PR TITLE
Handle label column as a string to avoid conversion errors

### DIFF
--- a/api/devDeploy.sh
+++ b/api/devDeploy.sh
@@ -22,7 +22,7 @@ cd v1alpha
 cd ../../
 gcloud builds submit --config api/v1alpha/cloudbuild.yaml --substitutions=TAG_NAME=${TAG}
 gcloud run deploy cds-api \
-  --image gcr.io/${PROJECT_ID}/cds-api:${TAG} \
+  --image gcr.io/${PROJECT_ID}/ds-api:${TAG} \
   --region=us-central1 \
   --allow-unauthenticated \
   --platform managed \

--- a/api/v1alpha/src/datasets/views/sqlBuilder.js
+++ b/api/v1alpha/src/datasets/views/sqlBuilder.js
@@ -140,7 +140,7 @@ async function generateAccessControlSubquery(view) {
         let useNesting = accessControlLabelColumnDelimiter && accessControlLabelColumnDelimiter.length > 0;
         if (useNesting === true) {
             query += `SELECT 1 FROM UNNEST(split(s.${accessControlLabelColumn}, "${accessControlLabelColumnDelimiter}")) AS flattenedLabel\n`;
-            query += `JOIN \`${view.projectId}.${cfg.cdsDatasetId}.${cfg.cdsCurrentUserPermissionViewId}\` e ON LOWER(flattenedLabel) = LOWER(e.tag)\n`;
+            query += `JOIN \`${view.projectId}.${cfg.cdsDatasetId}.${cfg.cdsCurrentUserPermissionViewId}\` e ON LOWER(CAST(flattenedLabel AS STRING)) = LOWER(e.tag)\n`;
             query += `WHERE\n\t(e.isTableBased IS false AND LOWER(e.datasetId) = '${view.datasetId.toLowerCase()}') OR\n`;
             query += `\t(e.isTableBased IS true AND LOWER(e.datasetId) = '${view.datasetId.toLowerCase()}' AND LOWER(e.tableId) = '${view.name.toLowerCase()}')\n`;
         }
@@ -148,7 +148,7 @@ async function generateAccessControlSubquery(view) {
             query += `SELECT 1 FROM \`${view.projectId}.${cfg.cdsDatasetId}.${cfg.cdsCurrentUserPermissionViewId}\` e\n`;
             query += `WHERE (\n\t(e.isTableBased IS false AND LOWER(e.datasetId) = '${view.datasetId.toLowerCase()}') OR\n`;
             query += `\t(e.isTableBased IS true AND LOWER(e.datasetId) = '${view.datasetId.toLowerCase()}' AND LOWER(e.tableId) = '${view.name.toLowerCase()}')\n)`;
-            query += `\nAND LOWER(e.tag) = LOWER(s.${accessControlLabelColumn})`;
+            query += `\nAND LOWER(e.tag) = LOWER(CAST(s.${accessControlLabelColumn} AS STRING))`;
         }
 
         sql += await prependLines(query, "\t", 1);

--- a/api/v1alpha/src/datasets/views/sqlBuilder.js
+++ b/api/v1alpha/src/datasets/views/sqlBuilder.js
@@ -139,7 +139,7 @@ async function generateAccessControlSubquery(view) {
         let query = "";
         let useNesting = accessControlLabelColumnDelimiter && accessControlLabelColumnDelimiter.length > 0;
         if (useNesting === true) {
-            query += `SELECT 1 FROM UNNEST(split(s.${accessControlLabelColumn}, "${accessControlLabelColumnDelimiter}")) AS flattenedLabel\n`;
+            query += `SELECT 1 FROM UNNEST(SPLIT(CAST(s.${accessControlLabelColumn} AS STRING), "${accessControlLabelColumnDelimiter}")) AS flattenedLabel\n`;
             query += `JOIN \`${view.projectId}.${cfg.cdsDatasetId}.${cfg.cdsCurrentUserPermissionViewId}\` e ON LOWER(CAST(flattenedLabel AS STRING)) = LOWER(e.tag)\n`;
             query += `WHERE\n\t(e.isTableBased IS false AND LOWER(e.datasetId) = '${view.datasetId.toLowerCase()}') OR\n`;
             query += `\t(e.isTableBased IS true AND LOWER(e.datasetId) = '${view.datasetId.toLowerCase()}' AND LOWER(e.tableId) = '${view.name.toLowerCase()}')\n`;


### PR DESCRIPTION
Fixes #275 

If a label column is of a type other than string, IE: int, the current split and lower functions will throw errors. As row-level access 'tags' within Datashare are all handled as strings, to fix this we are casting to string before performing these operations.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [X] Does your submission pass tests?
2. [X] Have you lint your code locally prior to submission?