### PR TITLE
'Manage on provider' button fix

### DIFF
--- a/api/v1alpha/istio-manifests/1.4/authz/allow-marketplace-service-account-policy.yaml
+++ b/api/v1alpha/istio-manifests/1.4/authz/allow-marketplace-service-account-policy.yaml
@@ -13,4 +13,4 @@ spec:
         - POST
         paths:
         - /v1alpha/projects/$PROJECT_ID/accounts:register
-        - /v1alpha/projects/$PROJECT_ID/procurements:myProducts
+        - /v1alpha/projects/$PROJECT_ID/procurements:myProducts?*

--- a/api/v1alpha/istio-manifests/1.4/authz/allow-marketplace-service-account-policy.yaml
+++ b/api/v1alpha/istio-manifests/1.4/authz/allow-marketplace-service-account-policy.yaml
@@ -13,4 +13,9 @@ spec:
         - POST
         paths:
         - /v1alpha/projects/$PROJECT_ID/accounts:register
+        - /v1alpha/projects/$PROJECT_ID/procurements:myProducts
+    - operation:
+        methods:
+        - GET
+        paths: 
         - /v1alpha/projects/$PROJECT_ID/procurements:myProducts?*

--- a/api/v1alpha/src/procurements/index.js
+++ b/api/v1alpha/src/procurements/index.js
@@ -223,4 +223,43 @@ procurements.post('/projects/:projectId/procurements:myProducts', async (req, re
     }
 });
 
+/**
+ * @swagger
+ *
+ * /projects/{projectId}/procurements:myProducts:
+ *   get:
+ *     summary: Performs redirect to the Datashare My Products UI page.
+ *     description: Returns a 301 redirect response
+ *     tags:
+ *       - procurements
+ *     parameters:
+ *     - in: path
+ *       name: projectId
+ *       schema:
+ *          type: string
+ *       required: true
+ *       description: Project Id of the Procurement request
+ *     responses:
+ *       301:
+ *         description: Redirect to My Products URL
+ */
+procurements.get('/projects/:projectId/procurements:myProducts', async (req, res) => {
+    const projectId = req.params.projectId;
+    const host = commonUtil.extractHostname(req.headers.host);
+
+    const token = req.query['x-gcp-marketplace-token'];
+    console.log(`Dashboard called for project ${projectId}, x-gcp-marketplace-token: ${token}, body: ${JSON.stringify(req.body)}`);
+
+    const accountManager = require('../accounts/dataManager');
+    const data = await accountManager.register(projectId, host, token);
+    console.log(`Data: ${JSON.stringify(data)}`);
+
+    if (data && data.success === false) {
+        res.redirect(cfg.uiBaseUrl + '/myProducts');
+    } else {
+        console.log(`Writing out cookie with token: ${token} for domain: ${host}`);
+        res.redirect(cfg.uiBaseUrl + '/myProducts');
+    }
+});
+
 module.exports = procurements;


### PR DESCRIPTION
Fixes #459 

It looks like marketplace logic was changed and now '?x-gcp-marketplace-token=' is appended to the url. Previously this button in marketplace would always perform a POST. What's strange is that while it's a GET, the request variable x-gcp-marketplace-token is empty. Assuming that this is a bug in marketplace, but want to handle the case for now. 

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [X] Does your submission pass tests?
2. [X] Have you lint your code locally prior to submission?