### PR TITLE
PubSub listener fixes

### DIFF
--- a/DEPLOYING_MARKETPLACE_LISTENER.md
+++ b/DEPLOYING_MARKETPLACE_LISTENER.md
@@ -10,16 +10,21 @@ export PROJECT_ID=$(gcloud config list --format 'value(core.project)')
 echo $PROJECT_ID
 
 export TAG=dev
-export REGION=us-central1
+export NAMESPACE=datashare-apis
 export SERVICE_ACCOUNT_NAME=ds-api-mgr
+CLUSTER=datashare
+gcloud config set compute/zone $ZONE
 
 gcloud builds submit --config api/v1alpha/listener-cloudbuild.yaml --substitutions=TAG_NAME=${TAG}
 
 gcloud run deploy "ds-listener-${PROJECT_ID}" \
-    --image gcr.io/${PROJECT_ID}/ds-listener:${TAG} \
-    --region=${REGION} \
-    --platform managed \
+    --cluster $CLUSTER \
+    --cluster-location $ZONE \
+    --min-instances 1 \
     --max-instances 1 \
+    --namespace $NAMESPACE \
+    --image gcr.io/${PROJECT_ID}/ds-listener:${TAG} \
+    --platform gke \
     --service-account ${SERVICE_ACCOUNT_NAME} \
-    --no-allow-unauthenticated
+    --update-env-vars=PROJECT_ID="${PROJECT_ID}"
 ```

--- a/DEPLOYING_MARKETPLACE_LISTENER.md
+++ b/DEPLOYING_MARKETPLACE_LISTENER.md
@@ -6,14 +6,14 @@ In order to integrate with Marketplace, a Datashare listener service needs to be
 # Deploying a listener
 ```
 # Set the projectId to the current project, or to the projectId of the project for which you need to listener for marketplace events (if using with multiple projects).
-export PROJECT_ID=$(gcloud config list --format 'value(core.project)')
-echo $PROJECT_ID
-
+export DEPLOYMENT_PROJECT_ID=$(gcloud config list --format 'value(core.project)')
+export PROJECT_ID="cds-demo-3"
+export ZONE=us-central1-a
+gcloud config set compute/zone $ZONE
 export TAG=dev
 export NAMESPACE=datashare-apis
 export SERVICE_ACCOUNT_NAME=ds-api-mgr
 CLUSTER=datashare
-gcloud config set compute/zone $ZONE
 
 gcloud builds submit --config api/v1alpha/listener-cloudbuild.yaml --substitutions=TAG_NAME=${TAG}
 
@@ -23,7 +23,7 @@ gcloud run deploy "ds-listener-${PROJECT_ID}" \
     --min-instances 1 \
     --max-instances 1 \
     --namespace $NAMESPACE \
-    --image gcr.io/${PROJECT_ID}/ds-listener:${TAG} \
+    --image gcr.io/${DEPLOYMENT_PROJECT_ID}/ds-listener:${TAG} \
     --platform gke \
     --service-account ${SERVICE_ACCOUNT_NAME} \
     --update-env-vars=PROJECT_ID="${PROJECT_ID}"

--- a/api/README.md
+++ b/api/README.md
@@ -249,7 +249,7 @@ Create a GKE cluster with the Cloud Run add-on:
 
     gcloud container clusters create $CLUSTER \
         --addons HorizontalPodAutoscaling,HttpLoadBalancing,CloudRun \
-        --cluster-version 1.17 \
+        --release-channel stable \
         --workload-pool=${PROJECT_ID}.svc.id.goog \
         --enable-ip-alias \
         --enable-stackdriver-kubernetes \

--- a/api/deploy.sh
+++ b/api/deploy.sh
@@ -123,7 +123,7 @@ if [ "${MARKETPLACE_INTEGRATION_ENABLED:=}" = "true" ]; then
     #     --memory 2Gi \
     #     --no-cpu-throttling
 
-    gcloud run "ds-listener-${PROJECT_ID}" \
+    gcloud run deploy "ds-listener-${PROJECT_ID}" \
         --cluster $CLUSTER \
         --cluster-location $ZONE \
         --min-instances 1 \

--- a/api/deploy.sh
+++ b/api/deploy.sh
@@ -110,6 +110,7 @@ if [ "${MARKETPLACE_INTEGRATION_ENABLED:=}" = "true" ]; then
     cd ../../
     gcloud builds submit --config api/v1alpha/listener-cloudbuild.yaml --substitutions=TAG_NAME=${TAG}
 
+    # TODO: Switch to Managed Cloud Run when this issue is resolved
     # --no-cpu-throttling is not working through gcloud alpha
     # ERROR: (gcloud.alpha.run.services.update) The annotation run.googleapis.com/cpu-throttling is not available
     # gcloud alpha run deploy "ds-listener-${PROJECT_ID}" \
@@ -123,7 +124,7 @@ if [ "${MARKETPLACE_INTEGRATION_ENABLED:=}" = "true" ]; then
     #     --memory 2Gi \
     #     --no-cpu-throttling
 
-    gcloud run deploy "ds-listener-${PROJECT_ID}" \
+    gcloud run deploy "ds-listener" \
         --cluster $CLUSTER \
         --cluster-location $ZONE \
         --min-instances 1 \

--- a/api/deploy.sh
+++ b/api/deploy.sh
@@ -110,12 +110,25 @@ if [ "${MARKETPLACE_INTEGRATION_ENABLED:=}" = "true" ]; then
     cd ../../
     gcloud builds submit --config api/v1alpha/listener-cloudbuild.yaml --substitutions=TAG_NAME=${TAG}
 
-    gcloud alpha run deploy "ds-listener-${PROJECT_ID}" \
-        --image gcr.io/${PROJECT_ID}/ds-listener:${TAG} \
-        --region=${REGION} \
-        --platform managed \
+    # --no-cpu-throttling is not working through gcloud alpha
+    # gcloud alpha run deploy "ds-listener-${PROJECT_ID}" \
+    #     --image gcr.io/${PROJECT_ID}/ds-listener:${TAG} \
+    #     --region=${REGION} \
+    #     --platform managed \
+    #     --max-instances 1 \
+    #     --service-account ${SERVICE_ACCOUNT_NAME} \
+    #     --no-allow-unauthenticated \
+    #     --cpu 1 \
+    #     --memory 2Gi \
+    #     --no-cpu-throttling
+
+    gcloud run "ds-listener-${PROJECT_ID}" \
+        --cluster $CLUSTER \
+        --cluster-location $ZONE \
+        --min-instances 1 \
         --max-instances 1 \
-        --service-account ${SERVICE_ACCOUNT_NAME} \
-        --no-allow-unauthenticated \
-        --no-cpu-throttling
+        --namespace $NAMESPACE \
+        --image gcr.io/${PROJECT_ID}/ds-listener:${TAG} \
+        --platform gke \
+        --service-account ${SERVICE_ACCOUNT_NAME}
 fi

--- a/api/deploy.sh
+++ b/api/deploy.sh
@@ -110,11 +110,12 @@ if [ "${MARKETPLACE_INTEGRATION_ENABLED:=}" = "true" ]; then
     cd ../../
     gcloud builds submit --config api/v1alpha/listener-cloudbuild.yaml --substitutions=TAG_NAME=${TAG}
 
-    gcloud run deploy "ds-listener-${PROJECT_ID}" \
+    gcloud alpha run deploy "ds-listener-${PROJECT_ID}" \
         --image gcr.io/${PROJECT_ID}/ds-listener:${TAG} \
         --region=${REGION} \
         --platform managed \
         --max-instances 1 \
         --service-account ${SERVICE_ACCOUNT_NAME} \
-        --no-allow-unauthenticated
+        --no-allow-unauthenticated \
+        --no-cpu-throttling
 fi

--- a/api/deploy.sh
+++ b/api/deploy.sh
@@ -111,6 +111,7 @@ if [ "${MARKETPLACE_INTEGRATION_ENABLED:=}" = "true" ]; then
     gcloud builds submit --config api/v1alpha/listener-cloudbuild.yaml --substitutions=TAG_NAME=${TAG}
 
     # --no-cpu-throttling is not working through gcloud alpha
+    # ERROR: (gcloud.alpha.run.services.update) The annotation run.googleapis.com/cpu-throttling is not available
     # gcloud alpha run deploy "ds-listener-${PROJECT_ID}" \
     #     --image gcr.io/${PROJECT_ID}/ds-listener:${TAG} \
     #     --region=${REGION} \

--- a/api/deploy.sh
+++ b/api/deploy.sh
@@ -46,7 +46,6 @@ cd "$(dirname "$0")"
 # Up to root
 cd ../
 gcloud builds submit --config api/v1alpha/api-cloudbuild.yaml --substitutions=TAG_NAME=${TAG}
-gcloud builds submit --config api/v1alpha/listener-cloudbuild.yaml --substitutions=TAG_NAME=${TAG}
 
 # Move to v1alpha
 cd api/v1alpha
@@ -65,8 +64,7 @@ gcloud run deploy ds-api \
     --platform gke \
     --service-account ${SERVICE_ACCOUNT_NAME} \
     --update-env-vars=OAUTH_CLIENT_ID="${OAUTH_CLIENT_ID}",DATA_PRODUCERS="${DATA_PRODUCERS}" \
-    --remove-env-vars=PROJECT_ID,MARKETPLACE_INTEGRATION \
-    --no-use-http2
+    --remove-env-vars=PROJECT_ID,MARKETPLACE_INTEGRATION
 
 if ! gcloud run services describe ds-api --cluster $CLUSTER --cluster-location $ZONE --namespace $NAMESPACE --platform gke | grep -q MANAGED_PROJECTS; then
     echo "MANAGED_PROJECTS env variable not found, creating it"
@@ -109,6 +107,9 @@ kubectl delete authorizationpolicy.security.istio.io -n "$NAMESPACE" --all
 cat istio-manifests/1.4/authz/* | envsubst | kubectl apply -f -
 
 if [ "${MARKETPLACE_INTEGRATION_ENABLED:=}" = "true" ]; then
+    cd ../../
+    gcloud builds submit --config api/v1alpha/listener-cloudbuild.yaml --substitutions=TAG_NAME=${TAG}
+
     gcloud run deploy "ds-listener-${PROJECT_ID}" \
         --image gcr.io/${PROJECT_ID}/ds-listener:${TAG} \
         --region=${REGION} \

--- a/api/v1alpha/package-lock.json
+++ b/api/v1alpha/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "cds-api",
-    "version": "0.0.1",
+    "version": "0.7.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "cds-api",
-            "version": "0.0.1",
+            "version": "0.7.3",
             "license": "Apache-2.0",
             "dependencies": {
                 "@google-cloud/resource-manager": "^2.0.0",

--- a/api/v1alpha/src/admin/dataManager.js
+++ b/api/v1alpha/src/admin/dataManager.js
@@ -23,7 +23,6 @@ const runtimeConfig = require('../lib/runtimeConfig');
 const metaManager = require('../lib/metaManager');
 const datasetManager = require('../datasets/dataManager');
 const procurementManager = require('../procurements/dataManager');
-const resourceManager = require('../resources/dataManager');
 const fs = require('fs');
 const retry = require('async-retry');
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cds-frontend",
-  "version": "0.1.0",
+  "version": "0.7.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cds-frontend",
-      "version": "0.1.0",
+      "version": "0.7.3",
       "dependencies": {
         "@mdi/font": "^5.5.55",
         "@mdi/js": "^5.5.55",


### PR DESCRIPTION
Fixes issue where PubSub listener is slow to start up, as resources aren't being allocated without http requests in cloud run. Changing the deploy setting to include [--no-cpu-throttling](https://cloud.google.com/sdk/gcloud/reference/alpha/run/deploy#--[no-]cpu-throttling).
### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [X] Does your submission pass tests?
2. [X] Have you lint your code locally prior to submission?