### PR TITLE
Multi project fixes

### DIFF
--- a/api/v1alpha/src/lib/auth.js
+++ b/api/v1alpha/src/lib/auth.js
@@ -23,7 +23,7 @@ const verifyProject = async (req, res, next) => {
         const managedProjects = await runtimeConfig.getManagedProjects();
         const isDefined = managedProjects != null && managedProjects.length > 0;
         if (isDefined === true && !managedProjects.includes(projectId)) {
-            console.warn(`Invalid project called: ${projectId}`);
+            console.warn(`Invalid unmanaged project called: ${projectId}`);
             return res
                 .status(401)
                 .send({ error: 'You are not authorized to make this project request' });

--- a/api/v1alpha/src/lib/auth.js
+++ b/api/v1alpha/src/lib/auth.js
@@ -18,9 +18,16 @@ const runtimeConfig = require('../lib/runtimeConfig');
 
 const verifyProject = async (req, res, next) => {
     const projectId = req.header('x-gcp-project-id');
+    const currentProjectId = await runtimeConfig.getCurrentProjectId();
     if (projectId) {
         const managedProjects = await runtimeConfig.getManagedProjects();
-        if (!managedProjects.includes(projectId)) {
+        const isDefined = managedProjects != null && managedProjects.length > 0;
+        if (isDefined === true && !managedProjects.includes(projectId)) {
+            console.warn(`Invalid project called: ${projectId}`);
+            return res
+                .status(401)
+                .send({ error: 'You are not authorized to make this project request' });
+        } else if (projectId !== currentProjectId) {
             console.warn(`Invalid project called: ${projectId}`);
             return res
                 .status(401)

--- a/api/v1alpha/src/lib/auth.js
+++ b/api/v1alpha/src/lib/auth.js
@@ -28,7 +28,7 @@ const verifyProject = async (req, res, next) => {
                 .status(401)
                 .send({ error: 'You are not authorized to make this project request' });
         } else if (projectId !== currentProjectId) {
-            console.warn(`Invalid project called: ${projectId}`);
+            console.warn(`Invalid project called: ${projectId}, currentProjectId: ${currentProjectId}`);
             return res
                 .status(401)
                 .send({ error: 'You are not authorized to make this project request' });

--- a/api/v1alpha/src/lib/runtimeConfig.js
+++ b/api/v1alpha/src/lib/runtimeConfig.js
@@ -65,7 +65,7 @@ class RuntimeConfig {
         // Check if maanged projects exists in cache first
         let list = dsCache.get(managedProjectsCacheKey);
         if (list == undefined) {
-            if (config.managedProjects && config.managedProjects.length > 0) {
+            if (config.managedProjects) {
                 const { Resource } = require('@google-cloud/resource-manager');
                 const options = {
                     scopes: ['https://www.googleapis.com/auth/cloud-platform']

--- a/api/v1alpha/src/lib/runtimeConfig.js
+++ b/api/v1alpha/src/lib/runtimeConfig.js
@@ -62,7 +62,7 @@ class RuntimeConfig {
     that the current account has access to
      */
     async getManagedProjects() {
-        // Check if maanged projects exists in cache first
+        // Check if managed projects exists in cache first
         let list = dsCache.get(managedProjectsCacheKey);
         if (list == undefined) {
             if (config.managedProjects) {
@@ -80,6 +80,13 @@ class RuntimeConfig {
                         .toLowerCase()
                         .localeCompare(b.toLowerCase());
                 });
+
+                const currentProject = await this.getCurrentProjectId();
+                if (include.includes(currentProject) && !list.includes(currentProject)) {
+                    // For the use case where the current project isn't returned from the resource manager call, append it to the list
+                    // It's safe to do so, as it's already included in the managed project list
+                    list.push(currentProject);
+                }
             }
             dsCache.set(managedProjectsCacheKey, list);
         }

--- a/api/v1alpha/src/lib/runtimeConfig.js
+++ b/api/v1alpha/src/lib/runtimeConfig.js
@@ -65,21 +65,22 @@ class RuntimeConfig {
         // Check if maanged projects exists in cache first
         let list = dsCache.get(managedProjectsCacheKey);
         if (list == undefined) {
-            const { Resource } = require('@google-cloud/resource-manager');
-            const options = {
-                scopes: ['https://www.googleapis.com/auth/cloud-platform']
-            };
-            const resource = new Resource(options);
+            if (config.managedProjects && config.managedProjects.length > 0) {
+                const { Resource } = require('@google-cloud/resource-manager');
+                const options = {
+                    scopes: ['https://www.googleapis.com/auth/cloud-platform']
+                };
+                const resource = new Resource(options);
 
-            // https://cloud.google.com/resource-manager/reference/rest/v1/projects/list
-            const [projects] = await resource.getProjects();
-            const include = Object.keys(config.managedProjects);
-            list = projects.filter(project => include.includes(project.id)).map(project => project.id).sort(function (a, b) {
-                return a
-                    .toLowerCase()
-                    .localeCompare(b.toLowerCase());
-            });
-
+                // https://cloud.google.com/resource-manager/reference/rest/v1/projects/list
+                const [projects] = await resource.getProjects();
+                const include = Object.keys(config.managedProjects);
+                list = projects.filter(project => include.includes(project.id)).map(project => project.id).sort(function (a, b) {
+                    return a
+                        .toLowerCase()
+                        .localeCompare(b.toLowerCase());
+                });
+            }
             // Set managed projects to cache for 5 minutes
             dsCache.set(managedProjectsCacheKey, list, 300);
         }

--- a/api/v1alpha/src/lib/runtimeConfig.js
+++ b/api/v1alpha/src/lib/runtimeConfig.js
@@ -81,8 +81,7 @@ class RuntimeConfig {
                         .localeCompare(b.toLowerCase());
                 });
             }
-            // Set managed projects to cache for 5 minutes
-            dsCache.set(managedProjectsCacheKey, list, 300);
+            dsCache.set(managedProjectsCacheKey, list);
         }
         return list;
     }

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -189,10 +189,12 @@ class Config {
         console.debug(`managed projects: ${JSON.stringify(response)}`);
         if (response.success) {
           const managedProjects = response.projects;
-          if (this.projectId === null) {
-            if (managedProjects.length > 0) {
-              this.projectId = managedProjects[0];
-            }
+          if (
+            this.projectId === null &&
+            managedProjects &&
+            managedProjects.length > 0
+          ) {
+            this.projectId = managedProjects[0];
           }
           return store.dispatch('setManagedProjects', managedProjects);
         }

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -169,6 +169,10 @@ class Config {
       return store.dispatch('getProjectConfiguration').then(response => {
         console.debug(`project configuration: ${JSON.stringify(response)}`);
         const _c = response.configuration;
+        if (!this.projectId) {
+          // If projectId is not set, set it.
+          this.projectId = _c.projectId;
+        }
         const labels = _c.labels;
         if (labels) {
           this.update(labels);


### PR DESCRIPTION
- Auth.js now protects use-case for when manage projects is not defined, and only allows calling of the current projectId.
- Get managed projects now includes the current projectId if it's not returned by the resource manager list call.
- UI now sets the current projectId based on the getProjectConfiguration response if it's not already set.
- 
### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [X] Does your submission pass tests?
2. [X] Have you lint your code locally prior to submission?