### PR TITLE
Initial login fix for admin role

### DIFF
--- a/frontend/src/api/server/index.js
+++ b/frontend/src/api/server/index.js
@@ -66,6 +66,7 @@ axios.interceptors.response.use(
     if (response.headers[forceTokenRefreshHeader]) {
       forceTokenRefresh = true;
       console.debug('Id Token refresh is required');
+      authManager.refreshClaims();
     }
     return validContentTypes.includes(response.headers['content-type'])
       ? response.data

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -191,7 +191,7 @@ class Config {
   }
 
   async reloadManagedProjects() {
-    if ((await authManager.isSignedIn()) === false) {
+    if (authManager.isSignedIn() === false) {
       console.debug('cannot reload configuration, user not logged in');
       return store.dispatch('setProjectConfiguration', null);
     }

--- a/frontend/src/mixins/authManager.js
+++ b/frontend/src/mixins/authManager.js
@@ -143,6 +143,23 @@ class AuthManager {
       });
   }
 
+  async refreshClaims() {
+    setTimeout(() => {
+      let currentUser = this.currentUser();
+      if (currentUser) {
+        currentUser.getIdTokenResult(true).then(result => {
+          const user = {
+            displayName: currentUser.displayName,
+            email: currentUser.email,
+            photoURL: currentUser.photoURL,
+            isDataProducer: result.claims.role === 'admin'
+          };
+          store.dispatch('fetchUser', user);
+        });
+      }
+    }, 3000);
+  }
+
   async onAuthSuccess(googleUser, reloadProjectConfigurationOnly) {
     console.debug('auth success called');
     if (googleUser) {


### PR DESCRIPTION
Fixes #594 

This is a work-around solution. It may make sense to have a separate login endpoint for Datashare, where the claim update and subsequent forced UI token refresh can basically be an ordered/sync operation. At this point, it would require more re-factoring though.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

1. [X] Does your submission pass tests?
2. [X] Have you lint your code locally prior to submission?